### PR TITLE
Setting retries to 0

### DIFF
--- a/HTTPShortcuts/src/ch/rmy/android/http_shortcuts/http/HttpRequester.java
+++ b/HTTPShortcuts/src/ch/rmy/android/http_shortcuts/http/HttpRequester.java
@@ -5,6 +5,7 @@ import android.widget.Toast;
 import ch.rmy.android.http_shortcuts.R;
 import ch.rmy.android.http_shortcuts.shortcuts.Shortcut;
 
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
@@ -60,6 +61,7 @@ public class HttpRequester {
 			}
 
 		});
+		stringRequest.setRetryPolicy(new DefaultRetryPolicy(DefaultRetryPolicy.DEFAULT_TIMEOUT_MS, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
 		queue.add(stringRequest);
 	}
 


### PR DESCRIPTION
I was getting two requests to my server when the request took more than 2500ms because the default number of retries is 1. I think 2500ms is too low and don't think there is a need for retry. This is especially important when the request is a toggle request. So I changed the num. of retries to 0. Let me know what you think.