### PR TITLE
Enable `setVariable` script function on some non-constants that remember value

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/models/Variable.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/models/Variable.kt
@@ -82,6 +82,18 @@ open class Variable(
     val isConstant
         get() = type == TYPE_CONSTANT
 
+    val isRememberValueSet
+        get() = rememberValue
+
+    val isText
+        get() = type == TYPE_TEXT
+
+    val isNumber
+        get() = type == TYPE_NUMBER
+
+    val isSlider
+        get() = type == TYPE_SLIDER
+
     override fun toString() = "Variable($type, $key, $id)"
 
     fun validate() {

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/scripting/actions/types/SetVariableAction.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/scripting/actions/types/SetVariableAction.kt
@@ -11,11 +11,11 @@ import io.reactivex.Completable
 
 class SetVariableAction(val variableKeyOrId: String, val value: String) : BaseAction() {
 
-    private fun validate(it: Variable, value: String): Boolean {
-        if ( it.isConstant ) return true
-        if ( it.isRememberValueSet ) {
-            if ( it.isText ) return true
-            if ( it.isNumber or it.isSlider ) {
+    private fun validate(variable: Variable, value: String): Boolean {
+        if ( variable.isConstant ) return true
+        if ( variable.isRememberValueSet ) {
+            if ( variable.isText ) return true
+            if ( variable.isNumber or variable.isSlider ) {
                 if ( value.all { it in '0' .. '9' } ) return true
             }
         }

--- a/HTTPShortcuts/app/src/main/res/values-pl/strings.xml
+++ b/HTTPShortcuts/app/src/main/res/values-pl/strings.xml
@@ -1415,7 +1415,7 @@ Możesz włączyć tę funkcję, edytując skrót i zaznaczając pole wyboru \"%
     <string name="error_variable_not_found_read">"Błąd zmiennej: próbowano uzyskać wartość zmiennej, która nie istnieje: %s"</string>
 
     <!-- Error message: Shown when a script tries to write to a variable that does not exist. %s is a placeholder for the name of the variable. -->
-    <string name="error_variable_not_found_write">"Błąd zmiennej: próbowano ustawić wartość zmiennej, która nie istnieje lub nie jest statyczna (stała): %s"</string>
+    <string name="error_variable_not_found_write">"Błąd zmiennej: próbowano ustawić wartość zmiennej, która nie istnieje lub nie obsługuje funkcjonalności: %s"</string>
 
     <!-- Title of code editor for defining global scripting code (JS code that runs before every shortcut) -->
     <string name="title_global_scripting">"Skrypt globalny"</string>

--- a/HTTPShortcuts/app/src/main/res/values/strings.xml
+++ b/HTTPShortcuts/app/src/main/res/values/strings.xml
@@ -807,7 +807,7 @@
     <!-- Error message: Shown when a script tries to read from a variable that does not exist. %s is a placeholder for the name of the variable. -->
     <string name="error_variable_not_found_read">Variable error: tried to get value of variable that doesn\'t exist: %s</string>
     <!-- Error message: Shown when a script tries to write to a variable that does not exist. %s is a placeholder for the name of the variable. -->
-    <string name="error_variable_not_found_write">Variable error: tried to set value of variable that doesn\'t exist or is not a static (constant): %s</string>
+    <string name="error_variable_not_found_write">Variable error: tried to set value of variable that doesn\'t exist or does not support it: %s</string>
     <!-- Button: Shown below JavaScript editor (for pre-request and post-request actions), allows to add snippets of JS code -->
     <string name="button_add_code_snippet">Add Code Snippet</string>
     <!-- Title: Shown on menu dialog (for pre-request and post-request actions), allows to add snippets of JS code -->

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -85,7 +85,14 @@ You can store a value as a string into a variable via the `setVariable()` functi
 setVariable('myVariable', 'Hello World');
 ```
 
-Please note that the `setVariable` function can only store values into static variables (i.e., constants), and that there is a size limit of 30000 characters. If the variable does not exist or is not a static variable, and error is raised.
+Please note that the `setVariable` function can only store values (no longer than 30000 characters) into:
+
+- static variables (i.e., constants),
+- text variable with "Remember value" option enabled,
+- number variable with "Remember value" option enabled,
+- number slider variable with "Remember value" option enabled.
+
+If the variable does not exist or it does not meet those conditions, and error is raised.
 
 <a name="shortcut-info"></a>
 ## Getting Information about the Current Shortcut


### PR DESCRIPTION
This should enable users to set non-static variables with `setVariable` scripting functions.
It would be useful to provide feedback to user on state of variables before the request is sent (e.g. number slider set to value reported by some response rather than to 0 or last remembered value)
It appears to work as intended (sample size of one).
