### PR TITLE
Deep link into DeepLinkActivity by NFC tag

### DIFF
--- a/HTTPShortcuts/app/src/main/AndroidManifest.xml
+++ b/HTTPShortcuts/app/src/main/AndroidManifest.xml
@@ -299,6 +299,13 @@
 
                 <data android:scheme="http-shortcuts" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="http-shortcuts" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
DeepLinkActivity is able to catch the DeepLink written to the NFC Tag.

Maybe https://github.com/Waboodoo/HTTP-Shortcuts/issues/209#issuecomment-772589854 problem can be solved.

Ref.
[Deep link into app (specific activity) by NFC tag](https://stackoverflow.com/questions/41360527/deep-link-into-app-specific-activity-by-nfc-tag)