### PR TITLE
allow to define polling shortcuts

### DIFF
--- a/HTTPShortcuts/app/build.gradle.kts
+++ b/HTTPShortcuts/app/build.gradle.kts
@@ -187,6 +187,7 @@ dependencies {
 
     /* Dependency Injection */
     implementation("com.google.dagger:dagger:2.41")
+    implementation("androidx.lifecycle:lifecycle-process:2.4.1")
     kapt("com.google.dagger:dagger-compiler:2.41")
 
     /* Support libraries */

--- a/HTTPShortcuts/app/src/main/AndroidManifest.xml
+++ b/HTTPShortcuts/app/src/main/AndroidManifest.xml
@@ -256,6 +256,11 @@
             android:windowSoftInputMode="adjustResize" />
 
         <activity
+            android:name=".activities.settings.polling.ShortcutPollingActivity"
+            android:label="@string/title_polling_shortcuts"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
             android:name=".activities.editor.scripting.codesnippets.CodeSnippetPickerActivity"
             android:label="@string/title_add_code_snippet"
             android:windowSoftInputMode="adjustResize" />

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/Application.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/Application.kt
@@ -52,5 +52,7 @@ class Application : android.app.Application(), ApplicationComponentProvider, Wit
         }
 
         DarkThemeHelper.applyDarkThemeSettings(Settings(context).darkThemeSetting)
+
+        PollingShortcutsWorker(context).startPolling()
     }
 }

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/PollingShortcutsWorker.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/PollingShortcutsWorker.kt
@@ -1,0 +1,101 @@
+package ch.rmy.android.http_shortcuts
+
+import android.app.ActivityManager
+import android.app.ActivityManager.RunningAppProcessInfo
+import android.content.Context
+import android.os.Handler
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import ch.rmy.android.http_shortcuts.dagger.getApplicationComponent
+import ch.rmy.android.http_shortcuts.data.domains.app.AppRepository
+import ch.rmy.android.http_shortcuts.data.enums.ShortcutExecutionType
+import ch.rmy.android.http_shortcuts.data.models.ResponseHandlingModel
+import ch.rmy.android.http_shortcuts.scheduling.ExecutionWorker
+import javax.inject.Inject
+
+
+class PollingShortcutsWorker(val context: Context) {
+
+    @Inject
+    lateinit var appRepository: AppRepository
+
+    init {
+        context.getApplicationComponent().inject(this)
+    }
+
+    fun startPolling() {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                super.onResume(owner)
+                start()
+            }
+        })
+    }
+
+    @Synchronized
+    private fun start() {
+        // TODO: replace by Looper
+        val handler = Handler()
+        // TODO: make delay configurable
+        val delay = 20_000L
+        handler.postDelayed(object : Runnable {
+            override fun run() {
+                if (isAppOnForeground()) {
+                    handler.postDelayed(this, delay)
+                }
+                // TOOD: This does not work because we don't save this (and don't want to save this),
+                // but the ExecutionWork only takes an id.
+                // Create a temporary copy from the shortcut?
+                appRepository.getPollingShortcuts().blockingGet().forEach {
+                    it.executionType = ShortcutExecutionType.TRIGGER.type
+                    it.responseHandling = ResponseHandlingModel(
+                        ResponseHandlingModel.UI_TYPE_TOAST,
+                        ResponseHandlingModel.SUCCESS_OUTPUT_NONE,
+                        ResponseHandlingModel.FAILURE_OUTPUT_SIMPLE,
+                    )
+                    if (javascriptIsClean(it.codeOnPrepare) && javascriptIsClean(it.codeOnFailure) && javascriptIsClean(
+                            it.codeOnSuccess
+                        )
+                    ) {
+                        ExecutionWorker.runPollingExecution(context, it)
+                    }
+
+                }
+            }
+        }, delay)
+    }
+
+    private fun javascriptIsClean(stringToCheck: String): Boolean {
+        // TODO: not very nice solution as the interaction menu might once be extended and this place here might be forgotten.
+        val forbiddenUserInteractions =
+            arrayOf(
+                "alert",
+                "showToast",
+                "showDialog",
+                "showSelection",
+                "prompt",
+                "confirm",
+                "playSound",
+                "speak",
+                "vibrate",
+                "scanBarcode",
+            )
+        for (f in forbiddenUserInteractions) {
+            if (f in stringToCheck.lowercase()) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun isAppOnForeground(): Boolean {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        for (appProcess in activityManager.runningAppProcesses ?: return false) {
+            if (appProcess.importance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND && appProcess.processName == context.packageName) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/PollingShortcutsAdapter.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/PollingShortcutsAdapter.kt
@@ -1,0 +1,107 @@
+package ch.rmy.android.http_shortcuts.activities.settings.polling
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import ch.rmy.android.framework.extensions.setText
+import ch.rmy.android.framework.ui.BaseAdapter
+import ch.rmy.android.http_shortcuts.activities.settings.polling.models.ShortcutListItem
+import ch.rmy.android.http_shortcuts.activities.settings.polling.models.ShortcutListItemId
+import ch.rmy.android.http_shortcuts.databinding.ListEmptyItemBinding
+import ch.rmy.android.http_shortcuts.databinding.ListItemShortcutTriggerBinding
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+
+class PollingShortcutsAdapter : BaseAdapter<ShortcutListItem>() {
+
+    sealed interface UserEvent {
+        data class ShortcutClicked(val id: ShortcutListItemId) : UserEvent
+    }
+
+    private val userEventSubject = PublishSubject.create<UserEvent>()
+
+    val userEvents: Observable<UserEvent>
+        get() = userEventSubject
+
+    override fun areItemsTheSame(oldItem: ShortcutListItem, newItem: ShortcutListItem): Boolean =
+        when (oldItem) {
+            is ShortcutListItem.Shortcut -> (newItem as? ShortcutListItem.Shortcut)?.id == oldItem.id
+            is ShortcutListItem.EmptyState -> newItem is ShortcutListItem.EmptyState
+        }
+
+    override fun getItemViewType(position: Int): Int =
+        when (items[position]) {
+            is ShortcutListItem.Shortcut -> VIEW_TYPE_SHORTCUT
+            is ShortcutListItem.EmptyState -> VIEW_TYPE_EMPTY_STATE
+        }
+
+    override fun createViewHolder(
+        viewType: Int,
+        parent: ViewGroup,
+        layoutInflater: LayoutInflater
+    ): RecyclerView.ViewHolder? =
+        when (viewType) {
+            VIEW_TYPE_SHORTCUT -> ShortcutViewHolder(
+                ListItemShortcutTriggerBinding.inflate(
+                    layoutInflater,
+                    parent,
+                    false
+                )
+            )
+            VIEW_TYPE_EMPTY_STATE -> EmptyStateViewHolder(
+                ListEmptyItemBinding.inflate(
+                    layoutInflater,
+                    parent,
+                    false
+                )
+            )
+            else -> null
+        }
+
+    override fun bindViewHolder(
+        holder: RecyclerView.ViewHolder,
+        position: Int,
+        item: ShortcutListItem,
+        payloads: List<Any>
+    ) {
+        when (holder) {
+            is EmptyStateViewHolder -> holder.setItem(item as ShortcutListItem.EmptyState)
+            is ShortcutViewHolder -> holder.setItem(item as ShortcutListItem.Shortcut)
+        }
+    }
+
+    inner class ShortcutViewHolder(
+        private val binding: ListItemShortcutTriggerBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        lateinit var id: ShortcutListItemId
+            private set
+
+        init {
+            binding.root.setOnClickListener {
+                userEventSubject.onNext(UserEvent.ShortcutClicked(id))
+            }
+        }
+
+        fun setItem(shortcut: ShortcutListItem.Shortcut) {
+            id = shortcut.id
+            binding.name.setText(shortcut.name)
+            binding.icon.setIcon(shortcut.icon)
+        }
+    }
+
+    inner class EmptyStateViewHolder(
+        private val binding: ListEmptyItemBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun setItem(item: ShortcutListItem.EmptyState) {
+            binding.emptyMarker.setText(item.title)
+            binding.emptyMarkerInstructions.setText(item.instructions)
+        }
+    }
+
+    companion object {
+        private const val VIEW_TYPE_SHORTCUT = 1
+        private const val VIEW_TYPE_EMPTY_STATE = 2
+    }
+}

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/ShortcutPollingActivity.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/ShortcutPollingActivity.kt
@@ -1,0 +1,96 @@
+package ch.rmy.android.http_shortcuts.activities.settings.polling
+
+import android.os.Bundle
+import androidx.recyclerview.widget.LinearLayoutManager
+import ch.rmy.android.framework.extensions.attachTo
+import ch.rmy.android.framework.extensions.bindViewModel
+import ch.rmy.android.framework.extensions.initialize
+import ch.rmy.android.framework.extensions.observe
+import ch.rmy.android.framework.ui.BaseIntentBuilder
+import ch.rmy.android.framework.utils.DragOrderingHelper
+import ch.rmy.android.http_shortcuts.R
+import ch.rmy.android.http_shortcuts.activities.BaseActivity
+import ch.rmy.android.http_shortcuts.data.domains.shortcuts.ShortcutId
+import ch.rmy.android.http_shortcuts.databinding.ActivityPollingShortcutsBinding
+import ch.rmy.android.http_shortcuts.extensions.applyTheme
+
+class ShortcutPollingActivity : BaseActivity() {
+
+    private val viewModel: ShortcutPollingViewModel by bindViewModel()
+
+    private lateinit var binding: ActivityPollingShortcutsBinding
+    private lateinit var adapter: PollingShortcutsAdapter
+
+    private var isDraggingEnabled = false
+
+    override fun onCreated(savedState: Bundle?) {
+        viewModel.initialize()
+        initViews()
+        initUserInputBindings()
+        initViewModelBindings()
+    }
+
+    private fun initViews() {
+        binding = applyBinding(ActivityPollingShortcutsBinding.inflate(layoutInflater))
+        setTitle(R.string.title_polling_shortcuts)
+
+        binding.buttonAddPollingShortcut.applyTheme(themeHelper)
+
+        val manager = LinearLayoutManager(context)
+        binding.shortcutPollingList.layoutManager = manager
+        binding.shortcutPollingList.setHasFixedSize(true)
+
+        adapter = PollingShortcutsAdapter()
+        binding.shortcutPollingList.adapter = adapter
+    }
+
+    private fun initUserInputBindings() {
+        adapter.userEvents
+            .subscribe { event ->
+                when (event) {
+                    is PollingShortcutsAdapter.UserEvent.ShortcutClicked -> {
+                        viewModel.onShortcutClicked(event.id)
+                    }
+                }
+            }
+            .attachTo(destroyer)
+
+        binding.buttonAddPollingShortcut.setOnClickListener {
+            viewModel.onAddButtonClicked()
+        }
+        initDragOrdering()
+    }
+
+    private fun initDragOrdering() {
+        val dragOrderingHelper = DragOrderingHelper(
+            isEnabledCallback = { isDraggingEnabled },
+            getId = { (it as? PollingShortcutsAdapter.ShortcutViewHolder)?.id },
+        )
+        dragOrderingHelper.attachTo(binding.shortcutPollingList)
+        dragOrderingHelper.movementSource
+            .subscribe { (shortcutId1, shortcutId2) ->
+                viewModel.onShortcutMoved(shortcutId1, shortcutId2)
+            }
+            .attachTo(destroyer)
+    }
+
+    private fun initViewModelBindings() {
+        viewModel.viewState.observe(this) { viewState ->
+            adapter.items = viewState.shortcuts
+            isDraggingEnabled = viewState.isDraggingEnabled
+            setDialogState(viewState.dialogState, viewModel)
+        }
+        viewModel.events.observe(this, ::handleEvent)
+    }
+
+    class IntentBuilder : BaseIntentBuilder(ShortcutPollingActivity::class) {
+
+        fun shortcutId(shortcutId: ShortcutId?) = also {
+            intent.putExtra(EXTRA_SHORTCUT_ID, shortcutId)
+        }
+    }
+
+    companion object {
+        private const val EXTRA_SHORTCUT_ID = "shortcutId"
+    }
+}

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/ShortcutPollingViewModel.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/ShortcutPollingViewModel.kt
@@ -1,0 +1,200 @@
+package ch.rmy.android.http_shortcuts.activities.settings.polling
+
+import android.app.Application
+import android.graphics.Typeface
+import android.text.SpannableString
+import android.text.style.StyleSpan
+import ch.rmy.android.framework.extensions.*
+import ch.rmy.android.framework.utils.localization.Localizable
+import ch.rmy.android.framework.utils.localization.StringResLocalizable
+import ch.rmy.android.framework.viewmodel.BaseViewModel
+import ch.rmy.android.framework.viewmodel.WithDialog
+import ch.rmy.android.framework.viewmodel.viewstate.DialogState
+import ch.rmy.android.http_shortcuts.R
+import ch.rmy.android.http_shortcuts.activities.settings.polling.models.ShortcutListItem
+import ch.rmy.android.http_shortcuts.activities.settings.polling.models.ShortcutListItemId
+import ch.rmy.android.http_shortcuts.dagger.getApplicationComponent
+import ch.rmy.android.http_shortcuts.data.domains.app.AppRepository
+import ch.rmy.android.http_shortcuts.data.domains.shortcuts.ShortcutId
+import ch.rmy.android.http_shortcuts.data.domains.shortcuts.ShortcutRepository
+import ch.rmy.android.http_shortcuts.data.models.ShortcutModel
+import ch.rmy.android.http_shortcuts.icons.ShortcutIcon
+import ch.rmy.android.http_shortcuts.scripting.shortcuts.ShortcutPlaceholder
+import com.afollestad.materialdialogs.WhichButton
+import com.afollestad.materialdialogs.actions.getActionButton
+import com.afollestad.materialdialogs.callbacks.onShow
+import javax.inject.Inject
+
+class ShortcutPollingViewModel(application: Application) :
+    BaseViewModel<Unit, ShortcutPollingViewState>(application), WithDialog {
+
+    @Inject
+    lateinit var appRepository: AppRepository
+
+    @Inject
+    lateinit var shortcutRepository: ShortcutRepository
+
+    init {
+        getApplicationComponent().inject(this)
+    }
+
+    private lateinit var shortcuts: List<ShortcutModel>
+
+    private var shortcutIdsInUse = emptyList<ShortcutListItemId>()
+        set(value) {
+            field = value
+            updateViewState {
+                copy(
+                    shortcuts = value.map(::getShortcutListItem)
+                        .ifEmpty { listOf(ShortcutListItem.EmptyState) },
+                )
+            }
+            performOperation(
+                appRepository.setPollingShortcuts(value.map {
+                    shortcutRepository.getShortcutById(it.shortcutId).blockingGet()
+                })
+            )
+        }
+
+    override var dialogState: DialogState?
+        get() = currentViewState?.dialogState
+        set(value) {
+            updateViewState {
+                copy(dialogState = value)
+            }
+        }
+
+    override fun initViewState() = ShortcutPollingViewState()
+
+    override fun onInitialized() {
+        shortcutRepository.getShortcuts()
+            .subscribe { shortcuts ->
+                this.shortcuts = shortcuts
+            }
+            .attachTo(destroyer)
+        appRepository.getPollingShortcuts()
+            .subscribe { shortcuts ->
+                shortcutIdsInUse = shortcuts
+                    .mapIndexed { index, shortcut ->
+                        ShortcutListItemId(
+                            shortcut.id,
+                            id = index.toString()
+                        )
+                    }
+            }
+            .attachTo(destroyer)
+    }
+
+    private fun getShortcutListItem(id: ShortcutListItemId) =
+        shortcuts
+            .firstOrNull { shortcut -> shortcut.id == id.shortcutId }
+            ?.let { shortcutPlaceholder ->
+                ShortcutListItem.Shortcut(
+                    id = id,
+                    name = shortcutPlaceholder.name.toLocalizable(),
+                    icon = shortcutPlaceholder.icon,
+                )
+            }
+            ?: ShortcutListItem.Shortcut(
+                id = id,
+                name = Localizable.create { context ->
+                    SpannableString(context.getString(R.string.placeholder_deleted_shortcut))
+                        .apply {
+                            setSpan(StyleSpan(Typeface.ITALIC), 0, length, 0)
+                        }
+                },
+                icon = ShortcutIcon.NoIcon,
+            )
+
+    fun onShortcutMoved(shortcutId1: ShortcutListItemId, shortcutId2: ShortcutListItemId) {
+        shortcutIdsInUse = shortcutIdsInUse.swapped(shortcutId1, shortcutId2) { this }
+    }
+
+    fun onAddButtonClicked() {
+        val placeholders = shortcuts.map(ShortcutPlaceholder::fromShortcut)
+
+        if (placeholders.isEmpty()) {
+            showNoShortcutsError()
+        } else {
+            showShortcutPickerForAdding(placeholders)
+        }
+    }
+
+    private fun showNoShortcutsError() {
+        dialogState = DialogState.create {
+            title(R.string.title_add_trigger_shortcut)
+                .message(R.string.error_add_trigger_shortcut_no_shortcuts)
+                .positive(R.string.dialog_ok)
+                .build()
+        }
+    }
+
+    private fun showShortcutPickerForAdding(placeholders: List<ShortcutPlaceholder>) {
+        val selectedShortcutIds = mutableSetOf<ShortcutId>()
+        var onSelectionChanged: () -> Unit = {}
+        dialogState = DialogState.create {
+            title(R.string.title_add_trigger_shortcut)
+                .runFor(placeholders) { shortcut ->
+                    checkBoxItem(
+                        name = shortcut.name,
+                        shortcutIcon = shortcut.icon,
+                        checked = { shortcut.id in selectedShortcutIds },
+                    ) { checked ->
+                        selectedShortcutIds.addOrRemove(shortcut.id, checked)
+                        onSelectionChanged()
+                    }
+                }
+                .positive(R.string.dialog_ok) {
+                    onAddShortcutDialogConfirmed(
+                        placeholders
+                            .map { it.id }
+                            .filter { it in selectedShortcutIds }
+                    )
+                }
+                .build()
+                .onShow { dialog ->
+                    val okButton = dialog.getActionButton(WhichButton.POSITIVE)
+                    onSelectionChanged = {
+                        okButton.isEnabled = selectedShortcutIds.isNotEmpty()
+                    }
+                        .apply { invoke() }
+                }
+        }
+    }
+
+    private fun onAddShortcutDialogConfirmed(shortcutIds: List<ShortcutId>) {
+        val offset = shortcutIdsInUse.size
+        shortcutIdsInUse = shortcutIdsInUse.plus(
+            shortcutIds.mapIndexed { index, shortcutId ->
+                ShortcutListItemId(shortcutId, (index + offset).toString())
+            }
+        )
+    }
+
+    private fun onRemoveShortcutDialogConfirmed(id: ShortcutListItemId) {
+        shortcutIdsInUse = shortcutIdsInUse.filter { it != id }
+    }
+
+    fun onShortcutClicked(id: ShortcutListItemId) {
+        val message = shortcuts
+            .firstOrNull { it.id == id.shortcutId }
+            ?.let { shortcut ->
+                StringResLocalizable(R.string.message_remove_trigger_shortcut, shortcut.name)
+            }
+            ?: StringResLocalizable(R.string.message_remove_deleted_trigger_shortcut)
+        showRemoveShortcutDialog(id, message)
+    }
+
+    private fun showRemoveShortcutDialog(id: ShortcutListItemId, message: Localizable) {
+        dialogState = DialogState.create {
+            title(R.string.title_remove_trigger_shortcut)
+                .message(message)
+                .positive(R.string.dialog_remove) {
+                    onRemoveShortcutDialogConfirmed(id)
+                }
+                .negative(R.string.dialog_cancel)
+                .build()
+        }
+    }
+
+}

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/ShortcutPollingViewState.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/ShortcutPollingViewState.kt
@@ -1,0 +1,12 @@
+package ch.rmy.android.http_shortcuts.activities.settings.polling
+
+import ch.rmy.android.framework.viewmodel.viewstate.DialogState
+import ch.rmy.android.http_shortcuts.activities.settings.polling.models.ShortcutListItem
+
+data class ShortcutPollingViewState(
+    val dialogState: DialogState? = null,
+    val shortcuts: List<ShortcutListItem> = emptyList(),
+) {
+    val isDraggingEnabled: Boolean
+        get() = shortcuts.size > 1
+}

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/models/ShortcutListItem.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/models/ShortcutListItem.kt
@@ -1,0 +1,22 @@
+package ch.rmy.android.http_shortcuts.activities.settings.polling.models
+
+import ch.rmy.android.framework.utils.localization.Localizable
+import ch.rmy.android.framework.utils.localization.StringResLocalizable
+import ch.rmy.android.http_shortcuts.R
+import ch.rmy.android.http_shortcuts.icons.ShortcutIcon
+
+sealed interface ShortcutListItem {
+    data class Shortcut(
+        val id: ShortcutListItemId,
+        val name: Localizable,
+        val icon: ShortcutIcon,
+    ) : ShortcutListItem
+
+    object EmptyState : ShortcutListItem {
+        val title: Localizable
+            get() = StringResLocalizable(R.string.empty_state_polling_shortcuts)
+
+        val instructions: Localizable
+            get() = StringResLocalizable(R.string.empty_state_polling_shortcuts_instructions)
+    }
+}

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/models/ShortcutListItemId.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/polling/models/ShortcutListItemId.kt
@@ -1,0 +1,5 @@
+package ch.rmy.android.http_shortcuts.activities.settings.polling.models
+
+import ch.rmy.android.http_shortcuts.data.domains.shortcuts.ShortcutId
+
+data class ShortcutListItemId(val shortcutId: ShortcutId, val id: String)

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/settings/SettingsActivity.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/settings/settings/SettingsActivity.kt
@@ -28,6 +28,7 @@ import ch.rmy.android.http_shortcuts.R
 import ch.rmy.android.http_shortcuts.activities.BaseActivity
 import ch.rmy.android.http_shortcuts.activities.settings.BaseSettingsFragment
 import ch.rmy.android.http_shortcuts.activities.settings.globalcode.GlobalScriptingActivity
+import ch.rmy.android.http_shortcuts.activities.settings.polling.ShortcutPollingActivity
 import ch.rmy.android.http_shortcuts.logging.Logging
 import ch.rmy.android.http_shortcuts.utils.DarkThemeHelper
 
@@ -121,6 +122,11 @@ class SettingsActivity : BaseActivity() {
                 openGlobalScriptingEditor()
             }
 
+            initPreference("polling_shortcuts") {
+                openPollingShortcutsList()
+            }
+
+
             findPreference<Preference>("privacy")!!.isVisible = Logging.supportsCrashReporting
             initListPreference("crash_reporting") { newValue ->
                 if (newValue == "false") {
@@ -171,6 +177,10 @@ class SettingsActivity : BaseActivity() {
 
         private fun openGlobalScriptingEditor() {
             GlobalScriptingActivity.IntentBuilder()
+                .startActivity(this)
+        }
+        private fun openPollingShortcutsList() {
+            ShortcutPollingActivity.IntentBuilder()
                 .startActivity(this)
         }
 

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/dagger/ApplicationComponent.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/dagger/ApplicationComponent.kt
@@ -1,6 +1,7 @@
 package ch.rmy.android.http_shortcuts.dagger
 
 import ch.rmy.android.http_shortcuts.Application
+import ch.rmy.android.http_shortcuts.PollingShortcutsWorker
 import ch.rmy.android.http_shortcuts.activities.ExecuteActivity
 import ch.rmy.android.http_shortcuts.activities.categories.CategoriesViewModel
 import ch.rmy.android.http_shortcuts.activities.categories.editor.CategoryEditorViewModel
@@ -37,6 +38,8 @@ import ch.rmy.android.http_shortcuts.activities.settings.about.AboutViewModel
 import ch.rmy.android.http_shortcuts.activities.settings.globalcode.GlobalScriptingActivity
 import ch.rmy.android.http_shortcuts.activities.settings.globalcode.GlobalScriptingViewModel
 import ch.rmy.android.http_shortcuts.activities.settings.importexport.ImportExportViewModel
+import ch.rmy.android.http_shortcuts.activities.settings.polling.ShortcutPollingActivity
+import ch.rmy.android.http_shortcuts.activities.settings.polling.ShortcutPollingViewModel
 import ch.rmy.android.http_shortcuts.activities.settings.settings.SettingsViewModel
 import ch.rmy.android.http_shortcuts.activities.variables.VariablesViewModel
 import ch.rmy.android.http_shortcuts.activities.variables.editor.VariableEditorViewModel
@@ -56,27 +59,10 @@ import ch.rmy.android.http_shortcuts.data.maintenance.CleanUpWorker
 import ch.rmy.android.http_shortcuts.plugin.PluginEditActivity
 import ch.rmy.android.http_shortcuts.scheduling.ExecutionWorker
 import ch.rmy.android.http_shortcuts.scheduling.ExecutionsWorker
-import ch.rmy.android.http_shortcuts.scripting.actions.types.ChangeDescriptionAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.ChangeIconAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.CopyToClipboardAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.EnqueueShortcutAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.GetClipboardContentAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.GetLocationAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.GetVariableAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.RenameShortcutAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.SetVariableAction
-import ch.rmy.android.http_shortcuts.scripting.actions.types.VibrateAction
+import ch.rmy.android.http_shortcuts.scripting.actions.types.*
 import ch.rmy.android.http_shortcuts.tiles.QuickTileService
 import ch.rmy.android.http_shortcuts.variables.VariableEditText
-import ch.rmy.android.http_shortcuts.variables.types.ClipboardType
-import ch.rmy.android.http_shortcuts.variables.types.ColorType
-import ch.rmy.android.http_shortcuts.variables.types.DateType
-import ch.rmy.android.http_shortcuts.variables.types.SelectType
-import ch.rmy.android.http_shortcuts.variables.types.SliderType
-import ch.rmy.android.http_shortcuts.variables.types.TextType
-import ch.rmy.android.http_shortcuts.variables.types.TimeType
-import ch.rmy.android.http_shortcuts.variables.types.ToggleType
-import ch.rmy.android.http_shortcuts.variables.types.UUIDType
+import ch.rmy.android.http_shortcuts.variables.types.*
 import ch.rmy.android.http_shortcuts.widget.WidgetProvider
 import dagger.BindsInstance
 import dagger.Component
@@ -140,6 +126,8 @@ interface ApplicationComponent {
     fun inject(aboutViewModel: AboutViewModel)
 
     fun inject(globalScriptingViewModel: GlobalScriptingViewModel)
+
+    fun inject(shortcutPollingViewModel: ShortcutPollingViewModel)
 
     fun inject(importExportViewModel: ImportExportViewModel)
 
@@ -207,6 +195,8 @@ interface ApplicationComponent {
 
     fun inject(globalScriptingActivity: GlobalScriptingActivity)
 
+    fun inject(ShortcutPollingActivity: ShortcutPollingActivity)
+
     fun inject(constantTypeFragment: ConstantTypeFragment)
 
     fun inject(selectTypeFragment: SelectTypeFragment)
@@ -250,4 +240,6 @@ interface ApplicationComponent {
     fun inject(displayResponseActivity: DisplayResponseActivity)
 
     fun inject(widgetSettingsViewModel: WidgetSettingsViewModel)
+
+    fun inject(pollingWorker: PollingShortcutsWorker)
 }

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/app/AppRepository.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/app/AppRepository.kt
@@ -23,6 +23,7 @@ import ch.rmy.android.http_shortcuts.import_export.Importer
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.kotlin.where
 import javax.inject.Inject
@@ -47,6 +48,26 @@ constructor(
                     ?.globalCode
                     ?: ""
             }
+
+    fun getPollingShortcuts(): Single<RealmList<ShortcutModel>> =
+        query {
+            getBase()
+        }
+            .map {
+                it.first().let { base ->
+                    base.pollingShortcuts
+                }
+            }
+
+    fun setPollingShortcuts(pollingShortcuts: List<ShortcutModel>): Completable =
+        commitTransaction {
+            getBase()
+                .findFirst()
+                ?.let { base ->
+                    base.pollingShortcuts.clear()
+                    base.pollingShortcuts.addAll(pollingShortcuts)
+                }
+        }
 
     fun getToolbarTitle(): Single<String> =
         queryItem {

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/migration/DatabaseMigration.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/migration/DatabaseMigration.kt
@@ -386,6 +386,10 @@ class DatabaseMigration : RealmMigration {
             53L -> { // 2.23.0
                 ResponseActionMigration.migrateRealm(realm)
             }
+            54L -> {
+                schema.get("Base")!!
+                    .addRealmListField("pollingShortcuts", schema.get("Shortcut"))
+            }
             else -> throw IllegalArgumentException("Missing migration for version $newVersion")
         }
         updateVersionNumber(realm, newVersion)
@@ -411,6 +415,6 @@ class DatabaseMigration : RealmMigration {
 
     companion object {
 
-        const val VERSION = 53L
+        const val VERSION = 54L
     }
 }

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/models/BaseModel.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/models/BaseModel.kt
@@ -18,6 +18,8 @@ open class BaseModel : RealmObject() {
     val shortcuts: List<ShortcutModel>
         get() = categories.flatMap { it.shortcuts }
 
+    var pollingShortcuts: RealmList<ShortcutModel> = RealmList()
+
     fun validate() {
         categories.forEach(CategoryModel::validate)
         variables.forEach(VariableModel::validate)

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/scheduling/ExecutionWorker.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/scheduling/ExecutionWorker.kt
@@ -10,6 +10,7 @@ import ch.rmy.android.http_shortcuts.dagger.getApplicationComponent
 import ch.rmy.android.http_shortcuts.data.RealmFactory
 import ch.rmy.android.http_shortcuts.data.domains.pending_executions.PendingExecutionsRepository
 import ch.rmy.android.http_shortcuts.data.models.PendingExecutionModel
+import ch.rmy.android.http_shortcuts.data.models.ShortcutModel
 import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -63,6 +64,13 @@ class ExecutionWorker(private val context: Context, workerParams: WorkerParamete
                 .tryNumber(pendingExecution.tryNumber)
                 .recursionDepth(pendingExecution.recursionDepth)
                 .executionId(pendingExecution.id)
+                .startActivity(context)
+        }
+
+        fun runPollingExecution(context: Context, shortcut: ShortcutModel) {
+            ExecuteActivity.IntentBuilder(shortcutId = shortcut.id)
+                .recursionDepth(0)
+                .executionId(shortcut.id)
                 .startActivity(context)
         }
     }

--- a/HTTPShortcuts/app/src/main/res/layout/activity_polling_shortcuts.xml
+++ b/HTTPShortcuts/app/src/main/res/layout/activity_polling_shortcuts.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/toolbar_layout" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/shortcut_polling_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    </androidx.recyclerview.widget.RecyclerView>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/button_add_polling_shortcut"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        app:srcCompat="@drawable/ic_create" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/HTTPShortcuts/app/src/main/res/values/strings.xml
+++ b/HTTPShortcuts/app/src/main/res/values/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="settings_global_scripting">Global Scripting</string>
     <!-- Subtitle of button in settings page to open code editor for defining global scripting code (JS code that runs before every shortcut) -->
     <string name="settings_global_scripting_summary">Run JavaScript code before every shortcut execution</string>
+    <string name="title_polling_shortcuts">Polling Shortcuts</string>
+    <string name="settings_polling_shortcuts_summary">Execute shortcuts periodically in the background.</string>
     <!-- Placeholder: Shown as placeholder/hint in scripting editor to prompt user to enter some code, which runs before the execution of every shortcut -->
     <string name="placeholder_javascript_global_scripting">Add JavaScript code here to run at the start of every shortcut execution, e.g., to prepare some variables or define some functions which can be used in a shortcut\'s Scripting section.</string>
     <!-- Action label: Shown on menu button to save changes in the Global Scripting editor -->
@@ -1285,4 +1287,6 @@
     <string name="label_dialog_action_none">None</string>
     <!-- Label on checkbox that allows to enable/disable the use of a certain action to be displayed in the HTTP response window (e.g. "Share" button) -->
     <string name="label_response_actions_show_button">Show \"%s\" button</string>
+    <string name="empty_state_polling_shortcuts_instructions">Add all shortcuts to this list that you want to trigger in the background. The first shortcut will be executed first.\n\nClick the + button to get started.</string>
+    <string name="empty_state_polling_shortcuts">You haven\'t added any shortcuts to be polled yet.</string>
 </resources>

--- a/HTTPShortcuts/app/src/main/res/xml/preferences.xml
+++ b/HTTPShortcuts/app/src/main/res/xml/preferences.xml
@@ -64,6 +64,11 @@
             app:key="global_scripting"
             app:summary="@string/settings_global_scripting_summary"
             app:title="@string/settings_global_scripting" />
+        <Preference
+            app:icon="@drawable/black_synchronize"
+            app:key="polling_shortcuts"
+            app:summary="@string/settings_polling_shortcuts_summary"
+            app:title="@string/title_polling_shortcuts" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
I had a look at the code and started to implement this (=> #293). The implementation is **not** very good right now (I copied the code for multi-shortcuts and changed not needed parts => leading to duplicated and maybe even unused code). **Consider it rather to be a proof-of-concept. So please don't merge it ;-)**

Current drawbacks:
- delay cannot be configured
- errors are not reported as toasts
- crash when you deleted a background/polling shortcut

I inlined my questions for you.


Apart from the conceptional questions there are the following todos:
- make interval configurable
- allow to enable/disable polling
- better icon