### PR TITLE
Fix MDNS host resolution via its .local domain

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/ServiceDiscoveryHelper.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/ServiceDiscoveryHelper.kt
@@ -4,90 +4,104 @@ import android.content.Context
 import android.net.Uri
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
+import android.util.Log
 import androidx.core.content.getSystemService
 import ch.rmy.android.framework.extensions.logInfo
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.Job
 import kotlin.time.Duration.Companion.seconds
 
 object ServiceDiscoveryHelper {
 
     private const val SERVICE_NAME_SUFFIX = ".local"
     private const val SERVICE_TYPE = "_http._tcp"
-    private val DISCOVER_TIMEOUT = 2.seconds
+    private val DISCOVER_TIMEOUT = 5.seconds
 
     fun isDiscoverable(uri: Uri) =
         uri.host?.endsWith(SERVICE_NAME_SUFFIX, ignoreCase = true) == true
 
     suspend fun discoverService(context: Context, serviceName: String): ServiceInfo {
-        coroutineScope {
-            launch {
-                delay(DISCOVER_TIMEOUT)
-                throw ServiceLookupTimeoutException()
+        val nsdManager = requireNotNull(context.getSystemService<NsdManager>())
+        var delayJob : Job? = null
+        var discoverError : Exception? = null
+        var rv : ServiceInfo? = null
+
+        logInfo("discoverService $serviceName")
+
+        val discoveryListener = object : NsdManager.DiscoveryListener {
+            private val tag = "DiscoveryListener"
+
+            override fun onStartDiscoveryFailed(serviceType: String?, errorCode: Int) {
+                Log.e(tag, "Start Discovery Failed")
+                discoverError = RuntimeException("Service Discovery Start Failed")
+                delayJob?.cancel()
             }
-        }
-        return suspendCancellableCoroutine { continuation ->
-            val nsdManager = requireNotNull(context.getSystemService<NsdManager>())
 
-            val discoveryListener = object : NsdManager.DiscoveryListener {
-                override fun onStartDiscoveryFailed(serviceType: String?, errorCode: Int) {
-                    logInfo("Start Discovery Failed")
-                    continuation.resumeWithException(RuntimeException("Service Discovery Start Failed"))
+            override fun onStopDiscoveryFailed(serviceType: String?, errorCode: Int) {
+                discoverError = RuntimeException("Service Discovery Stop Failed")
+                delayJob?.cancel()
+            }
+
+            override fun onDiscoveryStarted(serviceType: String?) {
+                Log.i(tag, "Service Discovery Started")
+            }
+
+            override fun onDiscoveryStopped(serviceType: String?) {
+                Log.i(tag, "Service Discovery Stopped")
+            }
+
+            override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+                Log.i(tag, "Service Found: ${serviceInfo.serviceName} ${serviceInfo.serviceType}")
+                if (!isCorrectServiceType(serviceInfo)) {
+                    return
                 }
-
-                override fun onStopDiscoveryFailed(serviceType: String?, errorCode: Int) {
-                    continuation.resumeWithException(RuntimeException("Service Discovery Stop Failed"))
-                }
-
-                override fun onDiscoveryStarted(serviceType: String?) {
-                    logInfo("Service Discovery Started")
-                }
-
-                override fun onDiscoveryStopped(serviceType: String?) {
-                    logInfo("Service Discovery Stopped")
-                }
-
-                override fun onServiceFound(serviceInfo: NsdServiceInfo) {
-                    logInfo("Service Found: ${serviceInfo.serviceName} ${serviceInfo.serviceType}")
-                    if (!isCorrectServiceType(serviceInfo)) {
-                        return
-                    }
-                    nsdManager.resolveService(
+                nsdManager.resolveService(
                         serviceInfo,
                         object : NsdManager.ResolveListener {
                             override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-                                logInfo("Resolve Failed")
+                                Log.i(tag, "Resolve Failed")
                             }
 
                             override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
-                                logInfo("Service Resolved")
+                                Log.i(tag, "Service Resolved")
                                 if (serviceInfo.serviceName.contains(serviceName.removeSuffix(SERVICE_NAME_SUFFIX), ignoreCase = true)) {
-                                    continuation.resume(
-                                        ServiceInfo(
-                                            address = serviceInfo.host.hostAddress!!,
-                                            port = serviceInfo.port,
-                                        )
+                                    rv = ServiceInfo(
+                                        address = serviceInfo.host.hostAddress!!,
+                                        port = serviceInfo.port,
                                     )
+                                    delayJob?.cancel()
                                 }
                             }
                         },
-                    )
-                }
-
-                override fun onServiceLost(serviceInfo: NsdServiceInfo?) {
-                    logInfo("Service Lost")
-                }
+                )
             }
 
-            nsdManager.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
-            continuation.invokeOnCancellation {
-                nsdManager.stopServiceDiscovery(discoveryListener)
+            override fun onServiceLost(serviceInfo: NsdServiceInfo?) {
+                Log.i(tag, "Service Lost")
             }
         }
+
+        nsdManager.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+
+        try {
+            coroutineScope {
+                launch {
+                    delayJob = coroutineContext[Job]
+                    delay(DISCOVER_TIMEOUT)
+                    throw ServiceLookupTimeoutException()
+                }
+            }
+
+            if(discoverError != null)
+                throw discoverError!!
+        } finally {
+            logInfo("stop discover")
+            nsdManager.stopServiceDiscovery(discoveryListener)
+        }
+
+        return rv!!
     }
 
     internal fun isCorrectServiceType(serviceInfo: NsdServiceInfo) =


### PR DESCRIPTION
The bug was introduced in 4615aa7, which waits for the delay coroutine to finish before starting the discovery, always triggering a ServiceLookupTimeoutException without any discovery taking place. This also extends the discovery timeout to 5 seconds and fixes the logging inside NsdManager.DiscoveryListener.

Please double check my code as Kotlin is new to me.