### PR TITLE
Fix soft keyboard padding (on older Android)

### DIFF
--- a/HTTPShortcuts/app/src/main/AndroidManifest.xml
+++ b/HTTPShortcuts/app/src/main/AndroidManifest.xml
@@ -92,7 +92,7 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
             android:exported="true"
             android:theme="@style/LoaderTheme"
-            android:windowSoftInputMode="adjustNothing">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Strange enough, recent Android versions (eg Android 14) don't seem to be affected either way but I guess it does no harm since it seems to be the recommended setting in the official [docs](https://developer.android.com/develop/ui/compose/system/insets-ui) on enabling edge-to-edge support...

| On / With | v3.30.2 | This PR |
| ----- | ----- | ----- |
| Android&nbsp;14 | ![Android 14, Samsung with the stock Samsung Keyboard. The current latest release.](https://github.com/user-attachments/assets/85a0338a-28a1-4181-81b8-9db2cb3f45b4) | ![Android 14, Samsung with the stock Samsung Keyboard. This PR.](https://github.com/user-attachments/assets/cd5ecce4-0f90-4de8-b26e-8edc5d6e94a1) |
| Android&nbsp;10 (Go&nbsp;Edition) | ![Android 10 Go Edition, Samsung with the stock Samsung Keyboard. Bottom part of the screen partially obscured by the soft keyboard in the current latest release.](https://github.com/user-attachments/assets/4cee5c33-50c3-4fb3-ad7f-3dd54bf1a7cd) | ![Android 10 Go Edition, Samsung with the stock Samsung Keyboard. `imePadding` adjusted for soft keyboard with this PR.](https://github.com/user-attachments/assets/d0ebec70-0a2f-41b2-b30e-a2a751736d7d) |

... but is otherwise just a minor UI bugfix : )

Thank you!