### PR TITLE
Fix getNextPendingExecution

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/pending_executions/PendingExecutionDao.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/pending_executions/PendingExecutionDao.kt
@@ -27,11 +27,11 @@ abstract class PendingExecutionDao {
     abstract suspend fun getPendingExecutionsForShortcut(shortcutId: ShortcutId): List<PendingExecutionWithVariablesModel>
 
     @Transaction
-    @Query("SELECT * FROM pending_execution ORDER BY enqueued_at ASC LIMIT 1")
+    @Query("SELECT * FROM pending_execution ORDER BY delay_until ASC, enqueued_at ASC LIMIT 1")
     abstract suspend fun getNextPendingExecution(): PendingExecutionWithVariablesModel?
 
     @Transaction
-    @Query("SELECT * FROM pending_execution WHERE wait_for_network = 1 ORDER BY enqueued_at ASC LIMIT 1")
+    @Query("SELECT * FROM pending_execution WHERE wait_for_network = 1 ORDER BY delay_until ASC, enqueued_at ASC LIMIT 1")
     abstract suspend fun getNextPendingExecutionWaitingForNetwork(): PendingExecutionWithVariablesModel?
 
     @Transaction


### PR DESCRIPTION
Kudos to the recent improvements on repetition scheduling, which is looking more and more promising!

I just gave it a try and was curious to find that `enqueueShortcut()` seems to get stalled while a repeating shortcut &mdash; having been initially executed &mdash; is afoot for reoccurrence; hence my attempted fix with this PR.

The proposed change to `getNextPendingExecution`, in essence, tries to query the next one forthcoming without being stuck at the schedule of the first triggered repeating shortcut.

I must confess I'm not very experienced or knowledgeable with Kotlin or SQL; but if I understand the code and syntax correctly, I think the Query syntax, which now reads:
```
SELECT * FROM pending_execution [...] ORDER BY delay_until ASC, enqueued_at ASC LIMIT 1
```
should cover the possible cases:

| Case | Covers |
| ----- | ----- |
| `delay_until == null` should, by default, come first when sorted in `ASC`ending order<ul><li>which are then sorted by `enqueued_at` in `ASC`ending order</li></ul> | Pending executions, eg enqueued shortcuts, without initial delay<ul><li>which is essentially the current behaviour, honouring insertion order |
| followed by `delay_until != null` in `ASC`ending order | Pending executions, eg repeating and enqueued shortcuts, with a delay (ie to be scheduled some time down the line)<ul><li>repeating shortcuts preserve their initial `enqueued_at` for future reoccurrences &mdash; essentially what gives in the current behaviour</li></ul> |
| `delay_until` should be greater (ie not earlier) than `enqueued_at` | `delay_until` is computed as `now()` plus a delay, which disregards negative value by application logic |
| `enqueued_at != null` | Computed as `now()`, non-null by type safety |
