### PR TITLE
Fix accidentally truncated shortcut descriptions on import

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/import_export/ImportRepository.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/import_export/ImportRepository.kt
@@ -231,7 +231,7 @@ constructor(
                 executionType = ShortcutExecutionType.parse(shortcut.executionType!!) ?: ShortcutExecutionType.HTTP,
                 categoryId = categoryId,
                 name = shortcut.name!!.truncate(Constants.SHORTCUT_NAME_MAX_LENGTH),
-                description = shortcut.description?.truncate(Constants.CATEGORY_NAME_MAX_LENGTH) ?: "",
+                description = shortcut.description?.truncate(Constants.SHORTCUT_DESCRIPTION_MAX_LENGTH) ?: "",
                 icon = ShortcutIcon.fromName(shortcut.iconName),
                 hidden = shortcut.hidden == true,
                 method = HttpMethod.parse(shortcut.method!!) ?: HttpMethod.GET,


### PR DESCRIPTION
Hmm... this was, I suppose, one of those inevitable moments where typos got inadvertently slipped in throughout the course of human experience ;-)

(just chanced upon this while debugging for the other PR)