### PR TITLE
`sendHttpRequest`: treat redirection codes as success when opting out `followRedirects`

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/scripting/actions/types/SendHttpRequestAction.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/scripting/actions/types/SendHttpRequestAction.kt
@@ -75,7 +75,14 @@ constructor(
             }
 
             executionContext.scriptingEngine.buildJsObject {
-                property("status", if (response.isSuccessful) "success" else "httpError")
+                property(
+                    "status",
+                    if (response.isSuccessful || (!followRedirects && response.isRedirect)) {
+                        "success"
+                    } else {
+                        "httpError"
+                    },
+                )
                 objectProperty("response") {
                     property(
                         "body",


### PR DESCRIPTION
Okhttp's <code>Response.[isSuccessful](https://square.github.io/okhttp/5.x/okhttp/okhttp3/-response/index.html#2095018859%2FProperties%2F985677359)</code> apparently considers only status codes in the range 200..299.  Perhaps it would be nice to also consider `3xx` redirection codes as `success` when `followRedirects` is disabled in `sendHttpRequest` 🤔