### PR TITLE
[BUG / Feature Request] Localization of date/time variables

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/DateType.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/DateType.kt
@@ -38,7 +38,7 @@ constructor(
         previousValue
             ?.let {
                 try {
-                    LocalDate.parse(it, DateTimeFormatter.ofPattern(DEFAULT_FORMAT, Locale.getDefault()))
+                    LocalDate.parse(it, DATE_FORMAT)
                 } catch (_: DateTimeParseException) {
                     null
                 }
@@ -50,7 +50,7 @@ constructor(
         const val KEY_FORMAT = "format"
         private const val DEFAULT_FORMAT = "yyyy-MM-dd"
 
-        internal val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_FORMAT, Locale.getDefault())
+        internal val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_FORMAT, Locale.US)
 
         fun getDateFormat(variable: GlobalVariable) =
             variable.getStringData(KEY_FORMAT) ?: DEFAULT_FORMAT

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/DateType.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/DateType.kt
@@ -30,7 +30,7 @@ constructor(
         if (variable.rememberValue) {
             variablesRepository.setVariableValue(variable.id, DATE_FORMAT.format(selectedDate))
         }
-        return SimpleDateFormat(getDateFormat(variable), Locale.US)
+        return SimpleDateFormat(getDateFormat(variable), Locale.getDefault())
             .format(Date.from(selectedDate.atStartOfDay(ZoneId.systemDefault()).toInstant()))
     }
 
@@ -38,7 +38,7 @@ constructor(
         previousValue
             ?.let {
                 try {
-                    LocalDate.parse(it, DateTimeFormatter.ofPattern(DEFAULT_FORMAT, Locale.US))
+                    LocalDate.parse(it, DateTimeFormatter.ofPattern(DEFAULT_FORMAT, Locale.getDefault()))
                 } catch (_: DateTimeParseException) {
                     null
                 }
@@ -50,7 +50,7 @@ constructor(
         const val KEY_FORMAT = "format"
         private const val DEFAULT_FORMAT = "yyyy-MM-dd"
 
-        internal val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_FORMAT, Locale.US)
+        internal val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_FORMAT, Locale.getDefault())
 
         fun getDateFormat(variable: GlobalVariable) =
             variable.getStringData(KEY_FORMAT) ?: DEFAULT_FORMAT

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/TimeType.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/TimeType.kt
@@ -50,7 +50,7 @@ constructor(
         const val KEY_FORMAT = "format"
         private const val DEFAULT_FORMAT = "HH:mm"
 
-        private val TIME_FORMAT = DateTimeFormatter.ofPattern("HH-mm", Locale.getDefault())
+        private val TIME_FORMAT = DateTimeFormatter.ofPattern("HH-mm", Locale.US)
 
         fun getTimeFormat(variable: GlobalVariable) =
             variable.getStringData(DateType.KEY_FORMAT) ?: DEFAULT_FORMAT

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/TimeType.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/variables/types/TimeType.kt
@@ -30,7 +30,7 @@ constructor(
         if (variable.rememberValue) {
             variablesRepository.setVariableValue(variable.id, TIME_FORMAT.format(selectedTime))
         }
-        return SimpleDateFormat(getTimeFormat(variable), Locale.US)
+        return SimpleDateFormat(getTimeFormat(variable), Locale.getDefault())
             .format(Date.from(LocalDate.now().atTime(selectedTime).atZone(ZoneOffset.systemDefault()).toInstant()))
     }
 
@@ -50,7 +50,7 @@ constructor(
         const val KEY_FORMAT = "format"
         private const val DEFAULT_FORMAT = "HH:mm"
 
-        private val TIME_FORMAT = DateTimeFormatter.ofPattern("HH-mm", Locale.US)
+        private val TIME_FORMAT = DateTimeFormatter.ofPattern("HH-mm", Locale.getDefault())
 
         fun getTimeFormat(variable: GlobalVariable) =
             variable.getStringData(DateType.KEY_FORMAT) ?: DEFAULT_FORMAT


### PR DESCRIPTION
I wanted to first just write a Bug Report / Feature request but found out, it can be easily fixed with an PR. Here is my original request:

### Steps To Reproduce
1. Create a new HTTP-Shortcut
2. Add a new local "select date" variable e.g to use in the Request-Body
3. Select a date format with localized value (e.g. `EEEE`)
4. When processed the variable will be always in english local, even though Android System Environment and App Setting is set to a different language

### Expected behavior
The date should be localized according to the system environment or according to a new field where the local code can be entered. This is actually already working for "current time" variable. Here the localization is working.

### Actual behavior
The date is always in english even though Android System Environment and App Setting is set to a different language

### Context
- Android OS Version: 16 Build 250705
- App Version 3.33.0
