### PR TITLE
WebViews: clear loading indicator on main-frame load errors

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/documentation/DocumentationWebView.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/documentation/DocumentationWebView.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
@@ -80,6 +81,13 @@ class DocumentationWebView(context: Context) : WebView(context) {
                 }
                 evaluateJavascript("""document.getElementsByTagName("h1")[0].innerText""") { pageTitle ->
                     onPageTitle(pageTitle.trim('"').takeUnless { it.isEmpty() || it == "null" || it == "Documentation" })
+                }
+            }
+
+            override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+                super.onReceivedError(view, request, error)
+                if (request.isForMainFrame) {
+                    hideLoading()
                 }
             }
         }

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/response/ResponseWebView.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/response/ResponseWebView.kt
@@ -3,6 +3,7 @@ package ch.rmy.android.http_shortcuts.activities.response
 import android.content.Context
 import android.net.Uri
 import android.util.AttributeSet
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
@@ -124,6 +125,13 @@ class ResponseWebView @JvmOverloads constructor(
 
             override fun onPageFinished(view: WebView?, url: String?) {
                 onLoaded()
+            }
+
+            override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+                super.onReceivedError(view, request, error)
+                if (request.isForMainFrame) {
+                    onLoaded()
+                }
             }
         }
 

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/components/SinglePageBrowser.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/components/SinglePageBrowser.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -123,6 +124,13 @@ private class SinglePageWebView(
                     onNavigationRequest(NavigationDestination.Documentation.buildRequest(request.url))
                 } else {
                     context.openURL(request.url)
+                }
+            }
+
+            override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+                super.onReceivedError(view, request, error)
+                if (request.isForMainFrame) {
+                    onLoaded()
                 }
             }
         }


### PR DESCRIPTION
Closes #555.

`DocumentationWebView`, `ResponseBrowser` and `SinglePageBrowser` all show a loading spinner that is hidden from inside `onPageFinished` (directly or via the `onLoaded` callback). None of them override `onReceivedError`, so a main-frame load failure leaves the spinner spinning forever:

```
showLoading()/isLoading = true
   -> network/cache error
   -> onPageFinished never fires
   -> hideLoading()/onLoaded() never runs
```

This is most reachable for the documentation view, which is configured with `blockNetworkLoads = true` and `cacheMode = LOAD_CACHE_ELSE_NETWORK`. The WebView is told to use only the cache, so a cache miss for the bundled documentation has no network fallback and the user is stuck on the spinner.

This PR adds `onReceivedError(view, request, error)` to each of the three WebViewClients and calls the same "loading is done" hook each one already uses:

```kotlin
override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
    super.onReceivedError(view, request, error)
    if (request.isForMainFrame) {
        hideLoading() // or onLoaded(), depending on file
    }
}
```

Notes:

- `request.isForMainFrame` is the guard so sub-resource errors are still ignored. The existing `onPageFinished` path is unchanged for successful loads.
- One new import per file (`android.webkit.WebResourceError`). No new permission, no new resource, no new dependency.
- Total diff is 24 lines added across 3 files.