### PR TITLE
feat: add network preference settings to shortcuts

### DIFF
--- a/HTTPShortcuts/app/src/main/AndroidManifest.xml
+++ b/HTTPShortcuts/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="com.android.launcher.permission.UNINSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsContent.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsContent.kt
@@ -26,6 +26,7 @@ import ch.rmy.android.http_shortcuts.components.SettingsButton
 import ch.rmy.android.http_shortcuts.components.Spacing
 import ch.rmy.android.http_shortcuts.components.VariablePlaceholderTextField
 import ch.rmy.android.http_shortcuts.data.enums.IpVersion
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ProxyType
 import ch.rmy.android.http_shortcuts.data.enums.ShortcutExecutionType
 
@@ -45,6 +46,7 @@ fun AdvancedSettingsContent(
     proxyPort: String,
     proxyUsername: String,
     proxyPassword: String,
+    networkPreference: NetworkPreference?,
     hostVerificationEnabled: Boolean,
     hostVerificationType: HostVerificationType,
     certificateFingerprint: String,
@@ -60,6 +62,7 @@ fun AdvancedSettingsContent(
     onProxyPortChanged: (String) -> Unit,
     onProxyUsernameChanged: (String) -> Unit,
     onProxyPasswordChanged: (String) -> Unit,
+    onNetworkPreferenceChanged: (NetworkPreference?) -> Unit,
     onHostVerificationTypeChanged: (HostVerificationType) -> Unit,
     onCertificateFingerprintChanged: (String) -> Unit,
 ) {
@@ -139,6 +142,26 @@ fun AdvancedSettingsContent(
                         IpVersion.V6 to "IPv6",
                     ),
                     onItemSelected = onIpVersionChanged,
+                )
+            }
+
+            HorizontalDivider()
+
+            Column(
+                modifier = Modifier.padding(Spacing.MEDIUM),
+                verticalArrangement = Arrangement.spacedBy(Spacing.SMALL),
+            ) {
+                SelectionField(
+                    title = stringResource(R.string.label_network_preference),
+                    selectedKey = networkPreference,
+                    items = listOf(
+                        null to stringResource(R.string.option_network_default),
+                        NetworkPreference.PREFER_CELLULAR to stringResource(R.string.option_network_prefer_cellular),
+                        NetworkPreference.ONLY_CELLULAR to stringResource(R.string.option_network_only_cellular),
+                        NetworkPreference.PREFER_WIFI to stringResource(R.string.option_network_prefer_wifi),
+                        NetworkPreference.ONLY_WIFI to stringResource(R.string.option_network_only_wifi),
+                    ),
+                    onItemSelected = onNetworkPreferenceChanged,
                 )
             }
 

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsScreen.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsScreen.kt
@@ -38,6 +38,7 @@ fun AdvancedSettingsScreen(
             proxyPort = viewState.proxyPort,
             proxyUsername = viewState.proxyUsername,
             proxyPassword = viewState.proxyPassword,
+            networkPreference = viewState.networkPreference,
             hostVerificationEnabled = viewState.hostVerificationEnabled,
             hostVerificationType = viewState.hostVerificationType,
             certificateFingerprint = viewState.certificateFingerprint,
@@ -53,6 +54,7 @@ fun AdvancedSettingsScreen(
             onProxyPortChanged = viewModel::onProxyPortChanged,
             onProxyUsernameChanged = viewModel::onProxyUsernameChanged,
             onProxyPasswordChanged = viewModel::onProxyPasswordChanged,
+            onNetworkPreferenceChanged = viewModel::onNetworkPreferenceChanged,
             onHostVerificationTypeChanged = viewModel::onHostVerificationTypeChanged,
             onCertificateFingerprintChanged = viewModel::onCertificateFingerprintChanged,
         )

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsViewModel.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsViewModel.kt
@@ -5,6 +5,7 @@ import ch.rmy.android.framework.viewmodel.BaseViewModel
 import ch.rmy.android.http_shortcuts.activities.editor.advancedsettings.models.HostVerificationType
 import ch.rmy.android.http_shortcuts.data.domains.shortcuts.TemporaryShortcutRepository
 import ch.rmy.android.http_shortcuts.data.enums.IpVersion
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ProxyType
 import ch.rmy.android.http_shortcuts.data.enums.SecurityPolicy
 import ch.rmy.android.http_shortcuts.data.models.Shortcut
@@ -46,6 +47,7 @@ constructor(
             proxyPassword = shortcut.proxyPassword ?: "",
             requireSpecificWifi = !shortcut.wifiSsid.isNullOrEmpty(),
             wifiSsid = shortcut.wifiSsid.orEmpty(),
+            networkPreference = shortcut.networkPreference,
         )
     }
 
@@ -212,6 +214,15 @@ constructor(
         }
         withProgressTracking {
             temporaryShortcutRepository.setWifiSsid(ssid)
+        }
+    }
+
+    fun onNetworkPreferenceChanged(networkPreference: NetworkPreference?) = runAction {
+        updateViewState {
+            copy(networkPreference = networkPreference)
+        }
+        withProgressTracking {
+            temporaryShortcutRepository.setNetworkPreference(networkPreference)
         }
     }
 

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsViewState.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/activities/editor/advancedsettings/AdvancedSettingsViewState.kt
@@ -5,6 +5,7 @@ import ch.rmy.android.framework.utils.localization.DurationLocalizable
 import ch.rmy.android.framework.utils.localization.Localizable
 import ch.rmy.android.http_shortcuts.activities.editor.advancedsettings.models.HostVerificationType
 import ch.rmy.android.http_shortcuts.data.enums.IpVersion
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ProxyType
 import ch.rmy.android.http_shortcuts.data.enums.ShortcutExecutionType
 import kotlin.time.Duration
@@ -28,6 +29,7 @@ data class AdvancedSettingsViewState(
     val proxyPassword: String,
     val requireSpecificWifi: Boolean,
     val wifiSsid: String,
+    val networkPreference: NetworkPreference?,
 ) {
     val timeoutSubtitle: Localizable
         get() = DurationLocalizable(timeout)

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/Converters.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/Converters.kt
@@ -12,6 +12,7 @@ import ch.rmy.android.http_shortcuts.data.enums.FileUploadType
 import ch.rmy.android.http_shortcuts.data.enums.HistoryEventType
 import ch.rmy.android.http_shortcuts.data.enums.HttpMethod
 import ch.rmy.android.http_shortcuts.data.enums.IpVersion
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ParameterType
 import ch.rmy.android.http_shortcuts.data.enums.ProxyType
 import ch.rmy.android.http_shortcuts.data.enums.RequestBodyType
@@ -264,4 +265,12 @@ class Converters {
     @TypeConverter
     fun serializeWidgetBackgroundType(widgetBackgroundType: WidgetBackgroundType) =
         widgetBackgroundType.serialize()
+
+    @TypeConverter
+    fun deserializeNetworkPreference(value: String?): NetworkPreference? =
+        value?.let { NetworkPreference.parse(it) }
+
+    @TypeConverter
+    fun serializeNetworkPreference(networkPreference: NetworkPreference?): String? =
+        networkPreference?.key
 }

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/Database.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/Database.kt
@@ -56,7 +56,7 @@ import ch.rmy.android.http_shortcuts.data.models.WorkingDirectory
         VariableWidget::class,
         WorkingDirectory::class,
     ],
-    version = 10,
+    version = 11,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -67,6 +67,7 @@ import ch.rmy.android.http_shortcuts.data.models.WorkingDirectory
         AutoMigration(from = 7, to = 8),
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
+        AutoMigration(from = 10, to = 11),
     ],
     exportSchema = true,
 )

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/import_export/ImportRepository.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/import_export/ImportRepository.kt
@@ -19,6 +19,7 @@ import ch.rmy.android.http_shortcuts.data.enums.ConfirmationType
 import ch.rmy.android.http_shortcuts.data.enums.FileUploadType
 import ch.rmy.android.http_shortcuts.data.enums.HttpMethod
 import ch.rmy.android.http_shortcuts.data.enums.IpVersion
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ParameterType
 import ch.rmy.android.http_shortcuts.data.enums.ProxyType
 import ch.rmy.android.http_shortcuts.data.enums.RequestBodyType
@@ -256,6 +257,7 @@ constructor(
                 quickSettingsTileShortcut = shortcut.quickSettingsTileShortcut == true,
                 delay = shortcut.delay ?: 0,
                 repetitionInterval = shortcut.repetitionInterval?.takeIf { it > 0 },
+                networkPreference = shortcut.networkPreference?.let { NetworkPreference.parse(it) },
                 contentType = shortcut.contentType ?: "",
                 fileUploadType = shortcut.fileUploadOptions
                     ?.fileUploadType

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/shortcuts/TemporaryShortcutRepository.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/domains/shortcuts/TemporaryShortcutRepository.kt
@@ -12,6 +12,7 @@ import ch.rmy.android.http_shortcuts.data.enums.ConfirmationType
 import ch.rmy.android.http_shortcuts.data.enums.FileUploadType
 import ch.rmy.android.http_shortcuts.data.enums.HttpMethod
 import ch.rmy.android.http_shortcuts.data.enums.IpVersion
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ParameterType
 import ch.rmy.android.http_shortcuts.data.enums.ProxyType
 import ch.rmy.android.http_shortcuts.data.enums.RequestBodyType
@@ -80,6 +81,12 @@ constructor(
     suspend fun setRepetitionInterval(interval: Duration? = null) {
         updateShortcut {
             copy(repetitionInterval = interval?.inWholeMinutes?.toInt())
+        }
+    }
+
+    suspend fun setNetworkPreference(networkPreference: NetworkPreference?) {
+        updateShortcut {
+            copy(networkPreference = networkPreference)
         }
     }
 

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/enums/NetworkPreference.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/enums/NetworkPreference.kt
@@ -1,0 +1,14 @@
+package ch.rmy.android.http_shortcuts.data.enums
+
+enum class NetworkPreference(val key: String) {
+    PREFER_CELLULAR("prefer_cellular"),
+    ONLY_CELLULAR("only_cellular"),
+    PREFER_WIFI("prefer_wifi"),
+    ONLY_WIFI("only_wifi"),
+    ;
+
+    companion object {
+        fun parse(key: String): NetworkPreference? =
+            entries.find { it.key == key }
+    }
+}

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/models/Shortcut.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/data/models/Shortcut.kt
@@ -16,6 +16,7 @@ import ch.rmy.android.http_shortcuts.data.enums.FileUploadType
 import ch.rmy.android.http_shortcuts.data.enums.HostVerificationConfig
 import ch.rmy.android.http_shortcuts.data.enums.HttpMethod
 import ch.rmy.android.http_shortcuts.data.enums.IpVersion
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ProxyType
 import ch.rmy.android.http_shortcuts.data.enums.RequestBodyType
 import ch.rmy.android.http_shortcuts.data.enums.ResponseContentType
@@ -79,6 +80,8 @@ data class Shortcut(
     val delay: Int,
     @ColumnInfo(name = "repetition_interval")
     val repetitionInterval: Int?,
+    @ColumnInfo(name = "network_preference")
+    val networkPreference: NetworkPreference?,
     @ColumnInfo(name = "content_type")
     val contentType: String,
     @ColumnInfo(name = "file_upload_type")
@@ -239,6 +242,7 @@ data class Shortcut(
                 quickSettingsTileShortcut = false,
                 delay = 0,
                 repetitionInterval = null,
+                networkPreference = null,
                 contentType = "",
                 fileUploadType = null,
                 fileUploadSourceDirectoryId = null,

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
@@ -1,6 +1,7 @@
 package ch.rmy.android.http_shortcuts.http
 
 import android.content.Context
+import android.net.Network
 import android.util.Base64
 import androidx.collection.LruCache
 import ch.rmy.android.framework.extensions.runFor
@@ -61,6 +62,7 @@ constructor() {
         val cookieJar: CookieJar?,
         val certificatePins: List<CertificatePin>,
         val hostVerificationConfig: HostVerificationConfig,
+        val network: Network?,
     )
 
     fun getClient(
@@ -76,6 +78,7 @@ constructor() {
         certificatePins: List<CertificatePin> = emptyList(),
         hostVerificationConfig: HostVerificationConfig = HostVerificationConfig.Default,
         userAgent: String? = null,
+        network: Network? = null,
     ): OkHttpClient {
         val cacheKey = CacheKey(
             clientCertParams = clientCertParams,
@@ -88,6 +91,7 @@ constructor() {
             cookieJar = cookieJar,
             certificatePins = certificatePins,
             hostVerificationConfig = hostVerificationConfig,
+            network = network,
         )
         val cachedClient = cache[cacheKey]
         if (cachedClient != null) {
@@ -160,6 +164,20 @@ constructor() {
                         .ifEmpty {
                             throw NoIpAddressException(hostname, it)
                         }
+                }
+            }
+            .runIfNotNull(network) { net ->
+                socketFactory(net.socketFactory)
+                dns { hostname ->
+                    val addresses = net.getAllByName(hostname).toList()
+                    ipVersion?.let { ver ->
+                        addresses.filter {
+                            when (ver) {
+                                IpVersion.V4 -> it is Inet4Address
+                                IpVersion.V6 -> it is Inet6Address
+                            }
+                        }.ifEmpty { throw NoIpAddressException(hostname, ver) }
+                    } ?: addresses
                 }
             }
             .build()

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
@@ -167,6 +167,9 @@ constructor() {
                 }
             }
             .runIfNotNull(network) { net ->
+                // Bind both TCP (socketFactory) and DNS (getAllByName) to the specified network.
+                // OkHttp dns() is a setter — this overrides the ipVersion DNS block above.
+                // The ipVersion filter is replicated here so it still applies when a network is bound.
                 socketFactory(net.socketFactory)
                 dns { hostname ->
                     val addresses = net.getAllByName(hostname).toList()

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpRequester.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpRequester.kt
@@ -184,7 +184,11 @@ constructor(
             NetworkPreference.PREFER_WIFI, NetworkPreference.ONLY_WIFI ->
                 NetworkCapabilities.TRANSPORT_WIFI
         }
-        val network = context.requestNetworkByTransport(transport)
+        val timeoutMs = when (preference) {
+            NetworkPreference.PREFER_CELLULAR, NetworkPreference.PREFER_WIFI -> PREFER_TIMEOUT_MS
+            NetworkPreference.ONLY_CELLULAR, NetworkPreference.ONLY_WIFI -> ONLY_TIMEOUT_MS
+        }
+        val network = context.requestNetworkByTransport(transport, timeoutMs)
         return if (network != null) {
             network
         } else when (preference) {
@@ -194,7 +198,7 @@ constructor(
         }
     }
 
-    private suspend fun Context.requestNetworkByTransport(transport: Int): Network? {
+    private suspend fun Context.requestNetworkByTransport(transport: Int, timeoutMs: Int): Network? {
         val connectivityManager = getSystemService<ConnectivityManager>() ?: return null
         return suspendCancellableCoroutine { continuation ->
             val request = NetworkRequest.Builder()
@@ -212,7 +216,7 @@ constructor(
                 }
             }
             try {
-                connectivityManager.requestNetwork(request, callback)
+                connectivityManager.requestNetwork(request, callback, timeoutMs)
             } catch (e: SecurityException) {
                 val fallback = connectivityManager.allNetworks.firstOrNull { network ->
                     connectivityManager.getNetworkCapabilities(network)
@@ -441,6 +445,9 @@ constructor(
     }
 
     companion object {
+
+        private const val PREFER_TIMEOUT_MS = 5_000
+        private const val ONLY_TIMEOUT_MS = 15_000
 
         internal fun prepareResponse(url: String, response: Response, contentFile: DocumentFile?, charsetOverride: Charset?) =
             ShortcutResponse(

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpRequester.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpRequester.kt
@@ -3,8 +3,13 @@ package ch.rmy.android.http_shortcuts.http
 import android.annotation.SuppressLint
 import android.content.ContentResolver
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import android.net.Uri
 import android.text.format.Formatter
+import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import ch.rmy.android.framework.extensions.isSuccessfulOrRedirect
@@ -12,6 +17,7 @@ import ch.rmy.android.framework.extensions.logInfo
 import ch.rmy.android.framework.extensions.takeUnlessEmpty
 import ch.rmy.android.framework.utils.FileUtil
 import ch.rmy.android.http_shortcuts.data.enums.FileUploadType
+import ch.rmy.android.http_shortcuts.data.enums.NetworkPreference
 import ch.rmy.android.http_shortcuts.data.enums.ParameterType
 import ch.rmy.android.http_shortcuts.data.enums.RequestBodyType
 import ch.rmy.android.http_shortcuts.data.enums.ShortcutAuthenticationType
@@ -90,6 +96,8 @@ constructor(
 
             val cookieJar = if (useCookieJar) cookieManager.getCookieJar() else null
 
+            val network = shortcut.networkPreference?.let { getNetworkForPreference(context, it) }
+
             try {
                 makeRequest(
                     context = context,
@@ -103,6 +111,7 @@ constructor(
                     cookieJar = cookieJar,
                     certificatePins = certificatePins,
                     progressTracker = progressTracker,
+                    network = network,
                 )
             } catch (e: UnknownHostException) {
                 ensureActive()
@@ -132,6 +141,7 @@ constructor(
                         cookieJar = cookieJar,
                         certificatePins = certificatePins,
                         progressTracker = progressTracker,
+                        network = network,
                     )
                 } else {
                     throw e
@@ -164,6 +174,58 @@ constructor(
         )
     }
 
+    private suspend fun getNetworkForPreference(
+        context: Context,
+        preference: NetworkPreference,
+    ): Network? {
+        val transport = when (preference) {
+            NetworkPreference.PREFER_CELLULAR, NetworkPreference.ONLY_CELLULAR ->
+                NetworkCapabilities.TRANSPORT_CELLULAR
+            NetworkPreference.PREFER_WIFI, NetworkPreference.ONLY_WIFI ->
+                NetworkCapabilities.TRANSPORT_WIFI
+        }
+        val network = context.requestNetworkByTransport(transport)
+        return if (network != null) {
+            network
+        } else when (preference) {
+            NetworkPreference.PREFER_CELLULAR, NetworkPreference.PREFER_WIFI -> null
+            NetworkPreference.ONLY_CELLULAR -> throw IOException("Cellular network not available")
+            NetworkPreference.ONLY_WIFI -> throw IOException("Wi-Fi network not available")
+        }
+    }
+
+    private suspend fun Context.requestNetworkByTransport(transport: Int): Network? {
+        val connectivityManager = getSystemService<ConnectivityManager>() ?: return null
+        return suspendCancellableCoroutine { continuation ->
+            val request = NetworkRequest.Builder()
+                .addTransportType(transport)
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build()
+            val callback = object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    connectivityManager.unregisterNetworkCallback(this)
+                    continuation.resume(network)
+                }
+                override fun onUnavailable() {
+                    connectivityManager.unregisterNetworkCallback(this)
+                    continuation.resume(null)
+                }
+            }
+            try {
+                connectivityManager.requestNetwork(request, callback)
+            } catch (e: SecurityException) {
+                val fallback = connectivityManager.allNetworks.firstOrNull { network ->
+                    connectivityManager.getNetworkCapabilities(network)
+                        ?.let { it.hasTransport(transport) && it.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } == true
+                }
+                continuation.resume(fallback)
+            }
+            continuation.invokeOnCancellation {
+                connectivityManager.unregisterNetworkCallback(callback)
+            }
+        }
+    }
+
     private suspend fun makeRequest(
         context: Context,
         shortcut: Shortcut,
@@ -176,6 +238,7 @@ constructor(
         cookieJar: CookieJar? = null,
         certificatePins: List<CertificatePin>,
         progressTracker: ProgressTracker?,
+        network: Network?,
     ): ShortcutResponse =
         suspendCancellableCoroutine { continuation ->
             val useDigestAuth = shortcut.authenticationType == ShortcutAuthenticationType.DIGEST
@@ -191,6 +254,7 @@ constructor(
                 certificatePins = certificatePins.map(CertificatePin::toCertificatePin),
                 clientCertParams = shortcut.clientCertParams,
                 hostVerificationConfig = shortcut.getSSLConfig(),
+                network = network,
             )
 
             val request = buildRequest(shortcut.method.method, requestData.url) {

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/import_export/ExportBaseLoader.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/import_export/ExportBaseLoader.kt
@@ -169,6 +169,7 @@ constructor(
                                 quickSettingsTileShortcut = shortcut.quickSettingsTileShortcut.trueOrNull(),
                                 delay = shortcut.delay.takeIf { it != 0 },
                                 repetitionInterval = shortcut.repetitionInterval,
+                                networkPreference = shortcut.takeIf { type == HTTP }?.networkPreference?.key,
                                 requestBodyType = shortcut.takeIf { type == HTTP }
                                     ?.requestBodyType
                                     ?.takeIf { it != RequestBodyType.CUSTOM_TEXT }?.type,

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/import_export/models/ImportExportShortcut.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/import_export/models/ImportExportShortcut.kt
@@ -33,6 +33,7 @@ data class ImportExportShortcut(
     val quickSettingsTileShortcut: Boolean? = false,
     val delay: Int? = null,
     val repetitionInterval: Int? = null,
+    val networkPreference: String? = null,
     val requestBodyType: String? = null,
     val contentType: String? = null,
     val responseHandling: ImportExportResponseHandling? = null,

--- a/HTTPShortcuts/app/src/main/res/values/strings.xml
+++ b/HTTPShortcuts/app/src/main/res/values/strings.xml
@@ -725,6 +725,12 @@
     <string name="subtitle_shortcut_as_file_share_target">Enabling this allows you to share files from other apps and use them for this shortcut\'s request body or form parameters.</string>
     <!-- Label for option in shortcut editor, selecting it will cause the shortcut to appear as an option in the Quick Settings Tile of the app -->
     <string name="label_quick_tile_shortcut">Allow triggering via Quick Settings Tile</string>
+    <string name="label_network_preference">Network Preference</string>
+    <string name="option_network_default">Use system default</string>
+    <string name="option_network_prefer_cellular">Prefer mobile data</string>
+    <string name="option_network_only_cellular">Mobile data only</string>
+    <string name="option_network_prefer_wifi">Prefer Wi-Fi</string>
+    <string name="option_network_only_wifi">Wi-Fi only</string>
     <!-- error message displayed when something goes wrong (e.g. response too big) when trying to share/export a response/text -->
     <string name="error_share_failed">An error occurred while sharing.</string>
     <!-- Generic error shown when an action fails because the device does not support it, e.g. importing from another app -->

--- a/HTTPShortcuts/app/src/main/res/values/strings.xml
+++ b/HTTPShortcuts/app/src/main/res/values/strings.xml
@@ -725,11 +725,17 @@
     <string name="subtitle_shortcut_as_file_share_target">Enabling this allows you to share files from other apps and use them for this shortcut\'s request body or form parameters.</string>
     <!-- Label for option in shortcut editor, selecting it will cause the shortcut to appear as an option in the Quick Settings Tile of the app -->
     <string name="label_quick_tile_shortcut">Allow triggering via Quick Settings Tile</string>
+    <!-- Label for dropdown in Advanced Settings to select which network interface to bind the HTTP request to -->
     <string name="label_network_preference">Network Preference</string>
+    <!-- Dropdown option for network preference: use the system default route (no socket or DNS binding) -->
     <string name="option_network_default">Use system default</string>
+    <!-- Dropdown option for network preference: prefer cellular, fall back to default if unavailable -->
     <string name="option_network_prefer_cellular">Prefer mobile data</string>
+    <!-- Dropdown option for network preference: only cellular, fail if unavailable -->
     <string name="option_network_only_cellular">Mobile data only</string>
+    <!-- Dropdown option for network preference: prefer Wi-Fi, fall back to default if unavailable -->
     <string name="option_network_prefer_wifi">Prefer Wi-Fi</string>
+    <!-- Dropdown option for network preference: only Wi-Fi, fail if unavailable -->
     <string name="option_network_only_wifi">Wi-Fi only</string>
     <!-- error message displayed when something goes wrong (e.g. response too big) when trying to share/export a response/text -->
     <string name="error_share_failed">An error occurred while sharing.</string>


### PR DESCRIPTION
## Summary

Adds per-shortcut network interface binding, allowing shortcuts to force HTTP traffic through a specific network (cellular or Wi-Fi) while keeping both TCP and DNS on the same interface.

## Motivation

On devices with both Wi-Fi and cellular connections active, the system always routes traffic through Wi-Fi (lower metric). Some use cases require shortcuts to use mobile data instead — for example, if Wi-Fi has no IPv6 but the cellular network does, connecting to IPv6-only domains will fail.

## Feature

A new **Network Preference** dropdown in Advanced Shortcut Settings with 5 options:
| Option | Behavior |
|---|---|
| System default | No binding — routes through default interface |
| Prefer mobile data | Binds to cellular if available (timeout 5s), falls back to default |
| Mobile data only | Strictly cellular (timeout 15s); fails if unavailable |
| Prefer Wi-Fi | Binds to Wi-Fi if available (timeout 5s), falls back to default |
| Wi-Fi only | Strictly Wi-Fi (timeout 15s); fails if unavailable |

The network is requested via `ConnectivityManager.requestNetwork()`, which requires the **CHANGE_NETWORK_STATE** permission. This will wake the cellular modem and may increase battery consumption.