### PR TITLE
Harden TLS protocol selection

### DIFF
--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
@@ -198,18 +198,28 @@ constructor() {
         }
     }
 
-    private fun OkHttpClient.Builder.configureTLS(
-        context: Context,
-        hostVerificationConfig: HostVerificationConfig,
-        clientCertParams: ClientCertParams?,
-    ): OkHttpClient.Builder =
-        run {
-            val trustManager = hostVerificationConfig.getTrustManager()
-            val sslContext = SSLContext.getInstance("TLS", "Conscrypt")
+private fun OkHttpClient.Builder.configureTLS(
+    context: Context,
+    hostVerificationConfig: HostVerificationConfig,
+    clientCertParams: ClientCertParams?,
+): OkHttpClient.Builder =
+    run {
+        val trustManager = hostVerificationConfig.getTrustManager()
+        val sslContext = SSLContext.getInstance("TLSv1.2", "Conscrypt")
 
-            val keyManagers = clientCertParams?.getKeyManagers(context)
-            sslContext.init(keyManagers, arrayOf(trustManager), null)
-            sslSocketFactory(TLSEnabledSSLSocketFactory(sslContext.socketFactory), trustManager)
+        val keyManagers = clientCertParams?.getKeyManagers(context)
+        sslContext.init(keyManagers, arrayOf(trustManager), null)
+        sslSocketFactory(TLSEnabledSSLSocketFactory(sslContext.socketFactory), trustManager)
+    }
+        .run {
+            when (hostVerificationConfig) {
+                HostVerificationConfig.Default -> this
+                is HostVerificationConfig.SelfSigned,
+                HostVerificationConfig.TrustAll,
+                -> {
+                    hostnameVerifier { _, _ -> true }
+                }
+            }
         }
             .run {
                 when (hostVerificationConfig) {

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/HttpClientFactory.kt
@@ -198,28 +198,18 @@ constructor() {
         }
     }
 
-private fun OkHttpClient.Builder.configureTLS(
-    context: Context,
-    hostVerificationConfig: HostVerificationConfig,
-    clientCertParams: ClientCertParams?,
-): OkHttpClient.Builder =
-    run {
-        val trustManager = hostVerificationConfig.getTrustManager()
-        val sslContext = SSLContext.getInstance("TLSv1.2", "Conscrypt")
+    private fun OkHttpClient.Builder.configureTLS(
+        context: Context,
+        hostVerificationConfig: HostVerificationConfig,
+        clientCertParams: ClientCertParams?,
+    ): OkHttpClient.Builder =
+        run {
+            val trustManager = hostVerificationConfig.getTrustManager()
+            val sslContext = SSLContext.getInstance("TLS", "Conscrypt")
 
-        val keyManagers = clientCertParams?.getKeyManagers(context)
-        sslContext.init(keyManagers, arrayOf(trustManager), null)
-        sslSocketFactory(TLSEnabledSSLSocketFactory(sslContext.socketFactory), trustManager)
-    }
-        .run {
-            when (hostVerificationConfig) {
-                HostVerificationConfig.Default -> this
-                is HostVerificationConfig.SelfSigned,
-                HostVerificationConfig.TrustAll,
-                -> {
-                    hostnameVerifier { _, _ -> true }
-                }
-            }
+            val keyManagers = clientCertParams?.getKeyManagers(context)
+            sslContext.init(keyManagers, arrayOf(trustManager), null)
+            sslSocketFactory(TLSEnabledSSLSocketFactory(sslContext.socketFactory), trustManager)
         }
             .run {
                 when (hostVerificationConfig) {

--- a/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/TLSEnabledSSLSocketFactory.kt
+++ b/HTTPShortcuts/app/src/main/kotlin/ch/rmy/android/http_shortcuts/http/TLSEnabledSSLSocketFactory.kt
@@ -30,7 +30,17 @@ class TLSEnabledSSLSocketFactory(private val sslSocketFactory: SSLSocketFactory)
     override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int) =
         withTLS(sslSocketFactory.createSocket(address, port, localAddress, localPort))
 
-    private fun withTLS(socket: Socket) = socket.apply {
-        (socket as? SSLSocket)?.enabledProtocols = arrayOf("TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3")
+    private fun withTLS(socket: Socket): Socket {
+        (socket as? SSLSocket)?.let { sslSocket ->
+            sslSocket.enabledProtocols =
+                sslSocket.enabledProtocols
+                    .filterNot { it in DEPRECATED_PROTOCOLS }
+                    .toTypedArray()
+        }
+        return socket
+    }
+
+    companion object {
+        private val DEPRECATED_PROTOCOLS = setOf("SSLv3", "TLSv1", "TLSv1.0", "TLSv1.1")
     }
 }


### PR DESCRIPTION
## Summary

This revision keeps Conscrypt's generic `TLS` context so TLS 1.3 and future provider-supported protocol versions remain available. The security policy is applied where protocols are actually configured: `TLSEnabledSSLSocketFactory` no longer replaces the provider defaults with a closed list that explicitly enabled TLS 1.0 and TLS 1.1.

## Changes

- keep `SSLContext.getInstance("TLS", "Conscrypt")` instead of pinning TLS 1.2;
- preserve the provider-enabled protocol set;
- remove only known deprecated SSL/TLS protocol names;
- apply the same policy to HTTP and MQTT users of the shared socket factory;
- restore the original `configureTLS` structure and project indentation.

## Compatibility

TLS 1.2 remains supported. TLS 1.3 and future protocols enabled by Conscrypt are not excluded. Endpoints that support only SSLv3, TLS 1.0, or TLS 1.1 will no longer connect through this custom socket factory.

## Validation

- [x] `git diff --check`
- [x] Change limited to TLS context/socket protocol configuration
- [ ] Gradle `ktlintCheck` (local Android Build Tools 36.0.0 installation is missing AAPT, so Gradle cannot configure all modules)

This supersedes the initial TLS 1.2 pin, which satisfied the analyzer's literal allowlist but could prevent TLS 1.3 negotiation.